### PR TITLE
Lab1 shading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Logs
 logs
 *.log

--- a/src/ConsoleRenderer.ts
+++ b/src/ConsoleRenderer.ts
@@ -1,14 +1,32 @@
 import Ray from './structures/ray/Ray';
 import { Renderer } from './types/Renderer';
 import { Scene } from './types/Scene';
+import { HitInfo } from './types/Traceable';
+import { findClosestHit } from './utils/findClosestHit';
 
 export default class ConsoleRenderer implements Renderer {
   constructor(public readonly scene: Scene) {}
 
+  private static dotProductSymbolMap(dot: number): string {
+    if (dot < -0.8) {
+      return '#';
+    }
+    if (dot < -0.5) {
+      return 'O';
+    }
+    if (dot < -0.2) {
+      return '*';
+    }
+    if (dot < 0) {
+      return '.';
+    }
+    return ' ';
+  }
+
   public render() {
     const { camera, objects } = this.scene;
 
-    for (let y = 0; y < camera.vResolution; y++) {
+    for (let y = camera.vResolution - 1; y >= 0; y--) {
       let result = '';
       for (let x = 0; x < camera.hResolution; x++) {
         const screenPixelPosition = camera.getScreenPixelCoordinates(x, y);
@@ -16,10 +34,18 @@ export default class ConsoleRenderer implements Renderer {
           camera.focalPoint,
           screenPixelPosition.toVector().subtract(camera.focalPoint.toVector())
         );
-
-        result += objects.some((object) => object.isIntersecting(ray))
-          ? '#'
-          : ' ';
+        const hits = objects
+          .map((object) => object.getIntersection(ray))
+          .filter((hit): hit is HitInfo => hit !== null);
+        if (hits.length === 0) {
+          result += ' ';
+          continue;
+        }
+        const closestHit = findClosestHit(hits);
+        const dot = this.scene.light.vector.dotProduct(
+          closestHit.normal.vector
+        );
+        result += ConsoleRenderer.dotProductSymbolMap(dot);
       }
       console.log(result);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import ConsoleRenderer from './ConsoleRenderer';
 import Camera from './structures/camera/Camera';
+import { DirectionalLight } from './structures/light/directional-light/DirectionalLight';
 import { Sphere } from './structures/sphere/Sphere';
 import Vector3D from './structures/vector/Vector3D';
 import Vertex3D from './structures/vertex/Vertex3D';
@@ -18,6 +19,7 @@ const sphere = new Sphere(new Vertex3D(10, 0, 0), 3);
 const mainScene: Scene = {
   camera,
   objects: [sphere],
+  light: new DirectionalLight(new Vector3D(5, 0, 0)),
 };
 
 const consoleRenderer = new ConsoleRenderer(mainScene);

--- a/src/structures/normal/Normal.ts
+++ b/src/structures/normal/Normal.ts
@@ -1,7 +1,6 @@
-import Ray from '../../ray/Ray';
-import Vector3D from '../../vector/Vector3D';
+import Vector3D from '../vector/Vector3D';
 
-export class DirectionalLight {
+export default class Normal3D {
   public readonly vector: Vector3D;
   constructor(vector: Vector3D) {
     this.vector = vector.normalize();

--- a/src/structures/plane/Plane.ts
+++ b/src/structures/plane/Plane.ts
@@ -1,12 +1,13 @@
+import Normal3D from '../normal/Normal';
 import Vector3D from '../vector/Vector3D';
 import Vertex3D from '../vertex/Vertex3D';
 
 export default class Plane {
-  public readonly vector: Vector3D;
+  public readonly normal: Normal3D;
   public readonly point: Vertex3D;
 
   constructor(vector: Vector3D, point: Vertex3D) {
-    this.vector = vector;
+    this.normal = new Normal3D(vector);
     this.point = point;
   }
 }

--- a/src/structures/ray/Ray.ts
+++ b/src/structures/ray/Ray.ts
@@ -7,7 +7,7 @@ export default class Ray {
 
   constructor(position: Vertex3D, vector: Vector3D) {
     this.position = position;
-    this.vector = vector;
+    this.vector = vector.normalize();
   }
 
   public hasInside(vertex: Vertex3D): boolean {

--- a/src/structures/sphere/Sphere.ts
+++ b/src/structures/sphere/Sphere.ts
@@ -1,6 +1,7 @@
 import { Traceable } from '../../types/Traceable';
 import Vertex3D from '../vertex/Vertex3D';
 import Ray from '../ray/Ray';
+import Normal3D from '../normal/Normal';
 
 export class Sphere implements Traceable {
   public readonly center: Vertex3D;
@@ -11,7 +12,7 @@ export class Sphere implements Traceable {
     this.radius = radius;
   }
 
-  public isIntersecting(ray: Ray): boolean {
+  public getIntersection(ray: Ray) {
     const a = ray.vector.dotProduct(ray.vector);
     // o - c vector
     const ocVector = ray.position.toVector().subtract(this.center.toVector());
@@ -20,14 +21,26 @@ export class Sphere implements Traceable {
     const D = b * b - 4 * a * c;
 
     if (D < 0) {
-      return false;
-    } else if (D === 0) {
-      const t = -b / (2 * a);
-      return t >= 0;
-    } else {
-      const t1 = (-b + Math.sqrt(D)) / (2 * a);
-      const t2 = (-b - Math.sqrt(D)) / (2 * a);
-      return t1 >= 0 || t2 >= 0;
+      return null;
     }
+    const t1 = (-b + Math.sqrt(D)) / (2 * a);
+    const t2 = (-b - Math.sqrt(D)) / (2 * a);
+    if (t1 < 0 && t2 < 0) {
+      return null;
+    }
+    let t;
+    if (t1 < 0) {
+      t = t2;
+    } else if (t2 < 0) {
+      t = t1;
+    } else {
+      t = Math.min(t1, t2);
+    }
+    const pHit = ray.position.toVector().add(ray.vector.multiply(t));
+    return {
+      normal: new Normal3D(pHit.subtract(this.center.toVector())),
+      pHit: pHit.toVertex3D(),
+      t: t / ray.vector.length,
+    };
   }
 }

--- a/src/types/Scene.ts
+++ b/src/types/Scene.ts
@@ -1,7 +1,10 @@
 import Camera from '../structures/camera/Camera';
+import { DirectionalLight } from '../structures/light/directional-light/DirectionalLight';
 import { Traceable } from './Traceable';
 
 export interface Scene {
   objects: Traceable[];
   camera: Camera;
+  // to add an ability for many sources in the future
+  light: DirectionalLight;
 }

--- a/src/types/Traceable.ts
+++ b/src/types/Traceable.ts
@@ -1,5 +1,14 @@
+import Normal3D from '../structures/normal/Normal';
 import Ray from '../structures/ray/Ray';
+import Vertex3D from '../structures/vertex/Vertex3D';
+
+export type HitInfo = {
+  normal: Normal3D;
+  pHit: Vertex3D;
+  // number of units from ray origin to intersection point
+  t: number;
+};
 
 export interface Traceable {
-  isIntersecting: (ray: Ray) => boolean;
+  getIntersection: (ray: Ray) => HitInfo | null;
 }

--- a/src/utils/findClosestHit.ts
+++ b/src/utils/findClosestHit.ts
@@ -1,0 +1,13 @@
+import { HitInfo } from '../types/Traceable';
+
+export const findClosestHit = (hits: HitInfo[]): HitInfo => {
+  let minT = hits[0].t;
+  let closestHit = hits[0];
+  for (let i = 1; i < hits.length; i++) {
+    if (hits[i].t < minT) {
+      closestHit = hits[i];
+      minT = hits[i].t;
+    }
+  }
+  return closestHit;
+};

--- a/tests/console-renderer.spec.ts
+++ b/tests/console-renderer.spec.ts
@@ -4,10 +4,11 @@ import ConsoleRenderer from '../src/ConsoleRenderer';
 import Camera from '../src/structures/camera/Camera';
 import Vertex3D from '../src/structures/vertex/Vertex3D';
 import Vector3D from '../src/structures/vector/Vector3D';
+import { DirectionalLight } from '../src/structures/light/directional-light/DirectionalLight';
 
 class MockObject implements Traceable {
-  public isIntersecting(): boolean {
-    return false;
+  public getIntersection() {
+    return null;
   }
 }
 
@@ -25,18 +26,19 @@ describe('ConsoleRenderer', () => {
       Math.PI / 4,
       100
     );
-    scene = { objects, camera };
+    const light = new DirectionalLight(new Vector3D(5, 0, 0));
+    scene = { objects, camera, light };
     renderer = new ConsoleRenderer(scene);
   });
 
   it('should render the scene to the console', () => {
-    const spy = jest.spyOn(console, 'log');
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => void 0);
     renderer.render();
     expect(spy).toHaveBeenCalled();
   });
 
   it('should render a pixel for each screen pixel', () => {
-    const spy = jest.spyOn(console, 'log');
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => void 0);
     renderer.render();
     expect(spy).toHaveBeenCalledTimes(camera.vResolution * 2);
     expect(spy.mock.calls[0][0].length).toEqual(camera.hResolution);

--- a/tests/plane.spec.ts
+++ b/tests/plane.spec.ts
@@ -8,7 +8,10 @@ describe('Plane', () => {
   const plane = new Plane(vector, point);
 
   test('constructor initializes vector and point', () => {
-    expect(plane.vector).toEqual(vector);
+    expect(plane.normal.vector.length).toEqual(1);
+    expect(plane.normal.vector.x).toEqual(plane.normal.vector.y);
+    expect(plane.normal.vector.y).toEqual(plane.normal.vector.z);
+    expect(plane.normal.vector.x).toBeGreaterThan(0);
     expect(plane.point).toEqual(point);
   });
 });

--- a/tests/sphere.spec.ts
+++ b/tests/sphere.spec.ts
@@ -16,24 +16,38 @@ describe('Sphere', () => {
   });
 
   describe('isIntersecting', () => {
-    it('should return true when the ray intersects the sphere', () => {
+    it('should return a correct inersection point, t and normal when the ray intersects the sphere', () => {
       const ray = new Ray(new Vertex3D(0, 0, -2), new Vector3D(0, 0, 1));
-      expect(sphere.isIntersecting(ray)).toBe(true);
+      const intersecion = sphere.getIntersection(ray);
+      expect(intersecion?.pHit).toEqual(new Vertex3D(0, 0, -1));
+      expect(intersecion?.normal.vector).toEqual(new Vector3D(0, 0, -1));
+      expect(intersecion?.t).toBe(1);
     });
 
-    it('should return false when the ray does not intersect the sphere', () => {
+    it('should return null when the ray does not intersect the sphere', () => {
       const ray = new Ray(new Vertex3D(0, 0, -2), new Vector3D(1, 1, 1));
-      expect(sphere.isIntersecting(ray)).toBe(false);
+      expect(sphere.getIntersection(ray)).toBe(null);
     });
 
-    it('should return true when the ray is tangent to the sphere', () => {
+    it('should return null when the ray intersects the sphere but only behind', () => {
+      const ray = new Ray(new Vertex3D(0, 0, 2), new Vector3D(0, 0, 1));
+      expect(sphere.getIntersection(ray)).toBe(null);
+    });
+
+    it('should return a correct intersection point, t and normal when the ray is tangent to the sphere', () => {
       const ray = new Ray(new Vertex3D(0, 1, 0), new Vector3D(1, 0, 0));
-      expect(sphere.isIntersecting(ray)).toBe(true);
+      const intersecion = sphere.getIntersection(ray);
+      expect(intersecion?.pHit).toEqual(new Vertex3D(0, 1, 0));
+      expect(intersecion?.normal.vector).toEqual(new Vector3D(0, 1, 0));
+      expect(intersecion?.t).toBeCloseTo(0);
     });
 
     it('should return true when the ray starts outside the sphere and goes through the center', () => {
       const ray = new Ray(new Vertex3D(0, 0, -2), new Vector3D(0, 0, 2));
-      expect(sphere.isIntersecting(ray)).toBe(true);
+      const intersecion = sphere.getIntersection(ray);
+      expect(intersecion?.pHit).toEqual(new Vertex3D(0, 0, -1));
+      expect(intersecion?.normal.vector).toEqual(new Vector3D(0, 0, -1));
+      expect(intersecion?.t).toBe(1);
     });
   });
 });

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,0 +1,30 @@
+import Normal3D from '../src/structures/normal/Normal';
+import Vector3D from '../src/structures/vector/Vector3D';
+import Vertex3D from '../src/structures/vertex/Vertex3D';
+import { HitInfo } from '../src/types/Traceable';
+import { findClosestHit } from '../src/utils/findClosestHit';
+
+describe('utils', () => {
+  const normal = new Normal3D(new Vector3D(0, 0, 1));
+  const hits: HitInfo[] = [
+    {
+      normal,
+      pHit: new Vertex3D(0, 0, 2),
+      t: 2,
+    },
+    {
+      normal,
+      pHit: new Vertex3D(0, 0, 1),
+      t: 1,
+    },
+    {
+      normal,
+      pHit: new Vertex3D(0, 0, 3),
+      t: 3,
+    },
+  ];
+  it('should compute the closest hit of several hits', () => {
+    const closestHit = findClosestHit(hits);
+    expect(closestHit).toBe(hits[1]);
+  });
+});


### PR DESCRIPTION
- add shading
- change Traceable interface to return normal, intersection point and distance to intersection from the ray origin
- add utility to compute the closest hit of all hit objects and make ConsoleRenderer reflect on it
- add Normal3D which keeps internal vector always normalized, also make some other structures always keep their internal vectors normalized (plane, ray, light)